### PR TITLE
Add a NixOS module for running latex_templater

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1711668574,
+        "narHash": "sha256-u1dfs0ASQIEr1icTVrsKwg2xToIpn7ZXxW3RHfHxshg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "219951b495fc2eac67b1456824cc1ec1fd2ee659",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,222 @@
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+  outputs = { self, nixpkgs }: {
+    nixosModules.latex_templater = { config, lib, pkgs, ... }:
+      let
+        uwsgi = pkgs.uwsgi.override { plugins = [ "python3" ]; };
+        latex_templater = ./latex_templater;
+        pyhonEnv = pkgs.python3.withPackages (ps: with ps; [ flask ]);
+        texlive = pkgs.texlive.combine {
+          inherit (pkgs.texlive) scheme-basic
+            anyfontsize pgf babel-hungarian hyphenat;
+        };
+        cfg = config.services.latex_templater;
+      in
+      {
+        options.services.latex_templater = {
+          enable = lib.mkEnableOption "the latex_templater service";
+          hostName = lib.mkOption {
+            type = lib.types.str;
+            description = lib.mdDoc "The nginx virtual host.";
+          };
+          urlPrefix = lib.mkOption {
+            type = lib.types.str;
+            default = "/latex_templater";
+            description = lib.mdDoc "The URL prefix under which the main page appears.";
+          };
+          port = lib.mkOption {
+            type = lib.types.port;
+            default = 5000;
+            description = lib.mdDoc "The local port the service binds to.";
+          };
+        };
+        config = lib.mkIf cfg.enable {
+          users = {
+            # Cannot use DynamicUser: https://github.com/NixOS/nixpkgs/pull/289593
+            users.latex_templater = {
+              group = "latex_templater";
+              isSystemUser = true;
+            };
+            groups.latex_templater = { };
+          };
+
+          systemd.services.latex_templater = {
+            description = "Latex templater";
+            path = [ texlive ];
+            serviceConfig = {
+              ExecStart = lib.strings.escapeShellArgs [
+                "${uwsgi}/bin/uwsgi"
+                "--http-socket"
+                "127.0.0.1:${toString cfg.port}"
+                "--plugins"
+                "python3"
+                "--pyhome"
+                "${pyhonEnv}"
+                "--wsgi-file"
+                "${latex_templater}/main.py"
+              ];
+              Restart = "on-failure";
+
+              # Paths
+              WorkingDirectory = "${latex_templater}";
+              ProtectProc = "invisible";
+              ProcSubset = "pid";
+
+              # User/Group Identity
+              User = config.users.users."latex_templater".name;
+              Group = config.users.groups."latex_templater".name;
+
+              # Capabilities
+              CapabilityBoundingSet = "";
+              AmbientCapabilities = "";
+
+              # Security
+              NoNewPrivileges = true;
+
+              # Process Properties
+              UMask = "0066";
+
+              # Sandboxing
+              ProtectHome = "tmpfs";
+              PrivateIPC = true;
+              ProtectHostname = true;
+              ProtectClock = true;
+              ProtectKernelLogs = true;
+              RestrictAddressFamilies = [ "AF_INET" ];
+              RestrictNamespaces = true;
+              LockPersonality = true;
+              MemoryDenyWriteExecute = true;
+              RestrictRealtime = true;
+              RestrictSUIDSGID = true;
+              RemoveIPC = true;
+
+              # System Call Filtering
+              SystemCallFilter = [
+                # Numbers are for x86-64
+                "read" # 0
+                "write" # 1
+                "close" # 3
+                "lseek" # 8
+                "rt_sigaction" # 13
+                "rt_sigprocmask" # 14
+                "ioctl" # 16
+                "pread64" # 17
+                "writev" # 20
+                "access" # 21
+                "dup2" # 33
+                "getpid" # 39
+                "sendfile" # 40
+                "socket" # 41
+                "connect" # 42
+                "bind" # 49
+                "listen" # 50
+                "getsockname" # 51
+                "setsockopt" # 54
+                "vfork" # 58
+                "wait4" # 61
+                "kill" # 62
+                "uname" # 63
+                "fcntl" # 72
+                "getcwd" # 79
+                "rename" # 82
+                "mkdir" # 83
+                "rmdir" # 84
+                "unlink" # 87
+                "readlink" # 89
+                "sysinfo" # 99
+                "prctl" # 157
+                "epoll_create" # 213
+                "getdents64" # 217
+                "restart_syscall" # 219
+                "timer_settime" # 223
+                "clock_gettime" # 228
+                "epoll_wait" # 232
+                "epoll_ctl" # 233
+                "openat" # 257
+                "newfstatat" # 262
+                "unlinkat" # 263
+                "accept4" # 288
+                "epoll_create1" # 291
+                "pipe2" # 293
+                "close_range" # 436
+              ];
+              SystemCallArchitectures = "native";
+
+              # CPU Accounting and Control
+              CPUWeight = 50;
+              CPUQuota = "100%";
+
+              # Memory Accounting and Control
+              # Measured max was 92MiB in practice
+              MemoryHigh = "128M";
+              MemoryMax = "200M";
+
+              # Process Accounting and Control
+              TasksMax = 8;
+
+              # Network Accounting and Control
+              IPAddressDeny = "any";
+              IPAddressAllow = "localhost";
+              SocketBindDeny = "any";
+              SocketBindAllow = "ipv4:tcp:${toString cfg.port}";
+              RestrictNetworkInterfaces = "lo";
+
+              # Device Access
+              DeviceAllow = "";
+            };
+            confinement = {
+              # This runs the service with a tmpfs based root filesystem, with
+              # only the needed store paths bind-mounted.
+              enable = true;
+              packages = [
+                # This needs to be added to the closure, otherwise python defaults to non-UTF8.
+                config.systemd.globalEnvironment.LOCALE_ARCHIVE
+                texlive
+              ];
+            };
+            wantedBy = [ "multi-user.target" ];
+          };
+
+          services.nginx = {
+            enable = lib.mkDefault true;
+            virtualHosts.${cfg.hostName} = {
+              locations."${cfg.urlPrefix}/".proxyPass = "http://127.0.0.1:${toString cfg.port}/";
+            };
+          };
+        };
+      };
+
+    # VM for testing/development. You can start it like this:
+    # `$(nix build --print-out-paths .#nixosConfigurations.test-vm.config.system.build.vm)/bin/run-nixos-vm`
+    nixosConfigurations.test-vm = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        self.nixosModules.latex_templater
+        ({ config, pkgs, modulesPath, ... }: {
+          imports = [ (modulesPath + "/virtualisation/qemu-vm.nix") ];
+          system.stateVersion = "23.11";
+          virtualisation = {
+            graphics = false;
+            forwardPorts = [{ from = "host"; host.port = 5000; guest.port = 80; }];
+          };
+          services.getty.autologinUser = "user";
+          users.extraUsers.user = {
+            password = "";
+            group = "wheel";
+            isNormalUser = true;
+          };
+          security.sudo = {
+            enable = true;
+            wheelNeedsPassword = false;
+          };
+          programs.bash.loginShellInit = ''trap "sudo poweroff" EXIT'';
+          services.latex_templater = {
+            enable = true;
+            hostName = "localhost";
+          };
+          networking.firewall.allowedTCPPorts = [ 80 ];
+        })
+      ];
+    };
+  };
+}


### PR DESCRIPTION
Building the current Containerfile would not be possible due to NixOS's sandboxing. Building a NixOS based OCI container would be possible, but the only advantage a container would provide on NixOS is sandboxing.

Systemd has a plethora of sandboxing options available, including the same facilities (namespaces) that containers use. I believe the systemd service introduced in this commit should actually be more secure than a regular container, given that it has all the same namespacing, plus many other things, for example a very restrictive seccomp filter.

Below is the output of `systemd-analyze security` for the service. There are still a few things that it deducts points for, but overall we are very close to a perfect score:
- `RestrictAddressFamilies=~AF_(INET|INET6)`, `PrivateNetwork=`, `IPAddressDeny=`: We could use unix sockets instead for proxying, but setting it up is non-trivial, so this is left as future work.
- `ProtectSystem=`, `ProtectHome=`: `ProtectSystem` is incompatible with the NixOS confinement option. Given that the service runs in a separate mount namespace with a separate root filesystem, these should not matter.
- `DeviceAllow=`: `ProtectClock=` implicitly  adds `char-rtc:r` here for some reason.

```
  NAME                                                        DESCRIPTION                                                                    EXPOSURE
✓ SystemCallFilter=~@swap                                     System call allow list defined for service, and @swap is not included
✓ SystemCallFilter=~@resources                                System call allow list defined for service, and @resources is not included
✓ SystemCallFilter=~@reboot                                   System call allow list defined for service, and @reboot is not included
✓ SystemCallFilter=~@raw-io                                   System call allow list defined for service, and @raw-io is not included
✓ SystemCallFilter=~@privileged                               System call allow list defined for service, and @privileged is not included
✓ SystemCallFilter=~@obsolete                                 System call allow list defined for service, and @obsolete is not included
✓ SystemCallFilter=~@mount                                    System call allow list defined for service, and @mount is not included
✓ SystemCallFilter=~@module                                   System call allow list defined for service, and @module is not included
✓ SystemCallFilter=~@debug                                    System call allow list defined for service, and @debug is not included
✓ SystemCallFilter=~@cpu-emulation                            System call allow list defined for service, and @cpu-emulation is not included
✓ SystemCallFilter=~@clock                                    System call allow list defined for service, and @clock is not included
✓ RemoveIPC=                                                  Service user cannot leave SysV IPC objects around
✓ User=/DynamicUser=                                          Service runs under a static non-root user identity
✓ RestrictRealtime=                                           Service realtime scheduling access is restricted
✓ CapabilityBoundingSet=~CAP_SYS_TIME                         Service processes cannot change the system clock
✓ NoNewPrivileges=                                            Service processes cannot acquire new privileges
✓ AmbientCapabilities=                                        Service process does not receive ambient capabilities
✓ CapabilityBoundingSet=~CAP_BPF                              Service may load BPF programs
✓ SystemCallArchitectures=                                    Service may execute system calls only with native ABI
✗ RestrictAddressFamilies=~AF_(INET|INET6)                    Service may allocate Internet sockets                                               0.3
✓ ProtectProc=                                                Service has restricted access to process tree (/proc hidepid=)
✓ SupplementaryGroups=                                        Service has no supplementary groups
✓ CapabilityBoundingSet=~CAP_SYS_RAWIO                        Service has no raw I/O access
✓ CapabilityBoundingSet=~CAP_SYS_PTRACE                       Service has no ptrace() debugging abilities
✓ CapabilityBoundingSet=~CAP_SYS_(NICE|RESOURCE)              Service has no privileges to change resource use parameters
✓ CapabilityBoundingSet=~CAP_NET_ADMIN                        Service has no network configuration privileges
✓ CapabilityBoundingSet=~CAP_NET_(BIND_SERVICE|BROADCAST|RAW) Service has no elevated networking privileges
✓ CapabilityBoundingSet=~CAP_AUDIT_*                          Service has no audit subsystem access
✓ CapabilityBoundingSet=~CAP_SYS_ADMIN                        Service has no administrator privileges
✓ PrivateTmp=                                                 Service has no access to other software's temporary files
✓ ProcSubset=                                                 Service has no access to non-process /proc files (/proc subset=)
✓ CapabilityBoundingSet=~CAP_SYSLOG                           Service has no access to kernel logging
✓ PrivateDevices=                                             Service has no access to hardware devices
✓ RootDirectory=/RootImage=                                   Service has its own root directory/image
✗ ProtectSystem=                                              Service has full access to the OS file hierarchy                                    0.2
✗ PrivateNetwork=                                             Service has access to the host's network                                            0.5
✗ ProtectHome=                                                Service has access to fake empty home directories                                   0.1
✗ DeviceAllow=                                                Service has a device ACL with some special devices: char-rtc:r                      0.1
✓ KeyringMode=                                                Service doesn't share key material with other services
✓ Delegate=                                                   Service does not maintain its own delegated control group subtree
✓ PrivateUsers=                                               Service does not have access to other users
✗ IPAddressDeny=                                              Service defines IP address allow list with only localhost entries                   0.1
✓ NotifyAccess=                                               Service child processes cannot alter service state
✓ ProtectClock=                                               Service cannot write to the hardware clock or system clock
✓ CapabilityBoundingSet=~CAP_SYS_PACCT                        Service cannot use acct()
✓ CapabilityBoundingSet=~CAP_KILL                             Service cannot send UNIX signals to arbitrary processes
✓ ProtectKernelLogs=                                          Service cannot read from or write to the kernel log ring buffer
✓ CapabilityBoundingSet=~CAP_WAKE_ALARM                       Service cannot program timers that wake up the system
✓ CapabilityBoundingSet=~CAP_(DAC_*|FOWNER|IPC_OWNER)         Service cannot override UNIX file/IPC permission checks
✓ ProtectControlGroups=                                       Service cannot modify the control group file system
✓ CapabilityBoundingSet=~CAP_LINUX_IMMUTABLE                  Service cannot mark files immutable
✓ CapabilityBoundingSet=~CAP_IPC_LOCK                         Service cannot lock memory into RAM
✓ ProtectKernelModules=                                       Service cannot load or read kernel modules
✓ CapabilityBoundingSet=~CAP_SYS_MODULE                       Service cannot load kernel modules
✓ CapabilityBoundingSet=~CAP_SYS_TTY_CONFIG                   Service cannot issue vhangup()
✓ CapabilityBoundingSet=~CAP_SYS_BOOT                         Service cannot issue reboot()
✓ CapabilityBoundingSet=~CAP_SYS_CHROOT                       Service cannot issue chroot()
✓ PrivateMounts=                                              Service cannot install system mounts
✓ CapabilityBoundingSet=~CAP_BLOCK_SUSPEND                    Service cannot establish wake locks
✓ MemoryDenyWriteExecute=                                     Service cannot create writable executable memory mappings
✓ RestrictNamespaces=~user                                    Service cannot create user namespaces
✓ RestrictNamespaces=~pid                                     Service cannot create process namespaces
✓ RestrictNamespaces=~net                                     Service cannot create network namespaces
✓ RestrictNamespaces=~uts                                     Service cannot create hostname namespaces
✓ RestrictNamespaces=~mnt                                     Service cannot create file system namespaces
✓ CapabilityBoundingSet=~CAP_LEASE                            Service cannot create file leases
✓ CapabilityBoundingSet=~CAP_MKNOD                            Service cannot create device nodes
✓ RestrictNamespaces=~cgroup                                  Service cannot create cgroup namespaces
✓ RestrictNamespaces=~ipc                                     Service cannot create IPC namespaces
✓ ProtectHostname=                                            Service cannot change system host/domainname
✓ CapabilityBoundingSet=~CAP_(CHOWN|FSETID|SETFCAP)           Service cannot change file ownership/access mode/capabilities
✓ CapabilityBoundingSet=~CAP_SET(UID|GID|PCAP)                Service cannot change UID/GID identities/capabilities
✓ LockPersonality=                                            Service cannot change ABI personality
✓ ProtectKernelTunables=                                      Service cannot alter kernel tunables (/proc/sys, …)
✓ RestrictAddressFamilies=~AF_PACKET                          Service cannot allocate packet sockets
✓ RestrictAddressFamilies=~AF_NETLINK                         Service cannot allocate netlink sockets
✓ RestrictAddressFamilies=~AF_UNIX                            Service cannot allocate local sockets
✓ RestrictAddressFamilies=~…                                  Service cannot allocate exotic sockets
✓ CapabilityBoundingSet=~CAP_MAC_*                            Service cannot adjust SMACK MAC
✓ RestrictSUIDSGID=                                           SUID/SGID file creation by service is restricted
✓ UMask=                                                      Files created by service are accessible only by service's own user by default

→ Overall exposure level for latex_templater.service: 1.1 OK 🙂
```